### PR TITLE
Fix PEAR bug 19683

### DIFF
--- a/tests/console_commandline_webrequest_2.phpt
+++ b/tests/console_commandline_webrequest_2.phpt
@@ -15,7 +15,7 @@ $parser->parse();
 Description of our parser goes here...
 
 Usage:
-  some_program [options] <simple> <multiple...>
+  some_program [options] simple [multiple1 multiple2 ...]
 
 Options:
   -t, --true                        test the StoreTrue action


### PR DESCRIPTION
Hello,

It seems that the unit tests failed (see PEAR bug #19683 https://pear.php.net/bugs/bug.php?id=19683 only because the test case is not up-to-date.

This PR fix it and corresponding to implementation code : see default renderer lines 209 to 218

https://github.com/pear/Console_CommandLine/blob/trunk/Console/CommandLine/Renderer/Default.php#L209

Please push a QA release ASAP
- Laurent

PS : 

```
C:\UwAmp\bin\php\php-5.3.20>phpunit C:\home\github\Console_CommandLine\tests\AllTests.php
PHPUnit 3.7.10 by Sebastian Bergmann.

.....................................................

Time: 34 seconds, Memory: 5.25Mb

OK (53 tests, 53 assertions)
```
