### PR TITLE
Composer: added include-path.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,6 @@
     },
     "autoload": {
         "psr-0": { "Console_CommandLine": "" }
-    }
+    },
+    "include-path": [""]
 }


### PR DESCRIPTION
CommandLine files contains many `require_once` calls. Because of that package directory must be added to include_path.
