### PR TITLE
fixed comparison to work in PHP7

### DIFF
--- a/Console/CommandLine.php
+++ b/Console/CommandLine.php
@@ -1122,7 +1122,7 @@ class Console_CommandLine
             // in short: handle -f<value> and -f <value>
             $next = substr($token, 2, 1);
             // check if we must wait for a value
-            if ($next === false) {
+            if ($next == false) {
                 if ($opt->expectsArgument()) {
                     if ($last && !$opt->argument_optional) {
                         throw Console_CommandLine_Exception::factory(


### PR DESCRIPTION
In PHP7 an empty string is not identical (===) to false, so the comparison should be with == instead of ===