### PR TITLE
Fix implode arg order

### DIFF
--- a/Console/CommandLine.php
+++ b/Console/CommandLine.php
@@ -935,7 +935,7 @@ class Console_CommandLine
         ) {
             throw Console_CommandLine_Exception::factory(
                 'SUBCOMMAND_REQUIRED',
-                array('commands' => implode(array_keys($this->commands), ', ')),
+                array('commands' => implode(', ', array_keys($this->commands))),
                 $this,
                 $this->messages
             );


### PR DESCRIPTION
With PHP 8

```
001+ Fatal error: Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, string given in /usr/share/pear/Console/CommandLine.php:938
002+ Stack trace:
003+ #0 /usr/share/pear/Console/CommandLine.php(938): implode(Array, ', ')
004+ #1 /dev/shm/BUILD/php-pear-Console-CommandLine-1.2.2/Console_CommandLine-1.2.2/tests/console_commandline_addcommand_3.php(10): Console_CommandLine->parse()
005+ #2 {main}
006+   thrown in /usr/share/pear/Console/CommandLine.php on line 938[remi@builder tests]$ 
```