### PR TITLE
CommandLine: ensure string functions receive strings

### DIFF
--- a/Console/CommandLine.php
+++ b/Console/CommandLine.php
@@ -737,7 +737,7 @@ class Console_CommandLine
      */
     public function findOption($str)
     {
-        $str = trim($str);
+        $str = trim((string) $str);
         if ($str === '') {
             return false;
         }
@@ -1010,6 +1010,7 @@ class Console_CommandLine
      */
     protected function parseToken($token, $result, &$args, $argc)
     {
+        $token = (string) $token;
         $last  = $argc === 0;
         if (!$this->_stopflag && $this->_lastopt) {
             if (strlen($token) > ($this->avoid_reading_stdin ? 1 : 0) &&

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "pear/console_commandline",
+    "name": "kornrunner/console_commandline",
     "description": "A full featured command line options and arguments parser.",
     "type": "library",
     "keywords": [
         "console"
     ],
-    "homepage": "https://github.com/pear/Console_CommandLine",
+    "homepage": "https://github.com/kornrunner/Console_CommandLine",
     "license": "MIT",
     "authors": [
         {
@@ -34,7 +34,7 @@
     ],
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_CommandLine",
-        "source": "https://github.com/pear/Console_CommandLine"
+        "source": "https://github.com/kornrunner/Console_CommandLine"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
These changes prevent deprecation notices on PHP 8.1 and are BC. Thanks!