### PR TITLE
[src] bug??

### DIFF
--- a/Console/CommandLine.php
+++ b/Console/CommandLine.php
@@ -1053,6 +1053,9 @@ class Console_CommandLine
                 return;
             }
         }
+        if (is_null($token)) {
+            $token = "";
+        }
         if (!$this->_stopflag && substr($token, 0, 2) == '--') {
             // a long option
             $optkv = explode('=', $token, 2);


### PR DESCRIPTION
While creating a command line tool, I found what may be a bug. I am not familiar with PHP.
I am probably using v8.1.12 PHP.
When I implemented a new option, I got this error.

PHP Deprecated:  substr(): Passing null to parameter #1 ($string) of type string is deprecated in ***/vendor/pear/console_commandline/Console/CommandLine.php on line 1056

Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in ***/vendor/pear/console_commandline/Console/CommandLine.php on line 1056
PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in ***/vendor/pear/console_commandline/Console/CommandLine.php on line 1103

Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in ***/vendor/pear/console_commandline/Console/CommandLine.php on line 1103

Therefore, I have added code to check the value before parsing the optional arguments.

https://www.php.net/manual/en/migration81.deprecated.php


